### PR TITLE
Use release of arch services

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,7 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/InputFragmentViewModel.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/InputFragmentViewModel.kt
@@ -10,6 +10,7 @@ import knaufdan.android.arch.databinding.bindTo
 import knaufdan.android.arch.mvvm.implementation.BaseViewModel
 import knaufdan.android.arch.navigation.INavigationService
 import knaufdan.android.core.preferences.ISharedPrefService
+import knaufdan.android.core.util.UnBoxUtil.safeUnBox
 import knaufdan.android.core.util.safeValue
 import knaufdan.android.simpletimerapp.ui.data.TimerConfiguration
 import knaufdan.android.simpletimerapp.util.Constants.HOUR_IN_MILLIS
@@ -19,7 +20,6 @@ import knaufdan.android.simpletimerapp.util.Constants.KEY_TIMER_CONFIGURATION
 import knaufdan.android.simpletimerapp.util.Constants.KEY_TIMER_STATE
 import knaufdan.android.simpletimerapp.util.Constants.MINUTE_IN_MILLIS
 import knaufdan.android.simpletimerapp.util.Constants.SECOND_IN_MILLIS
-import knaufdan.android.simpletimerapp.util.UnBoxUtil.safeUnBox
 import knaufdan.android.simpletimerapp.util.determineClockSections
 import knaufdan.android.simpletimerapp.util.service.TimerState
 

--- a/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/TimerFragmentViewModel.kt
+++ b/app/src/main/java/knaufdan/android/simpletimerapp/ui/fragments/TimerFragmentViewModel.kt
@@ -10,6 +10,7 @@ import knaufdan.android.arch.mvvm.implementation.BaseViewModel
 import knaufdan.android.arch.navigation.INavigationService
 import knaufdan.android.core.alarm.IAlarmService
 import knaufdan.android.core.preferences.ISharedPrefService
+import knaufdan.android.core.util.UnBoxUtil.safeUnBox
 import knaufdan.android.services.service.IServiceDispatcher
 import knaufdan.android.services.service.broadcast.Action
 import knaufdan.android.services.service.broadcast.ActionDispatcher
@@ -25,7 +26,6 @@ import knaufdan.android.simpletimerapp.util.Constants.KEY_LINEAR_INCREMENT
 import knaufdan.android.simpletimerapp.util.Constants.KEY_PAUSE_TIME
 import knaufdan.android.simpletimerapp.util.Constants.KEY_TIMER_STATE
 import knaufdan.android.simpletimerapp.util.Constants.SECOND_IN_MILLIS
-import knaufdan.android.simpletimerapp.util.UnBoxUtil.safeUnBox
 import knaufdan.android.simpletimerapp.util.alarm.AlarmReceiver
 import knaufdan.android.simpletimerapp.util.service.TimerAction
 import knaufdan.android.simpletimerapp.util.service.TimerService

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -14,5 +14,5 @@ object Versions {
     const val jUnit_version = "4.12"
     const val test_runner_version = "1.2.0"
 
-    const val archServices_version = "master-SNAPSHOT"
+    const val archServices_version = "0.1.0"
 }


### PR DESCRIPTION
- target first release instead of snapshot
- more robust against ArchServices changes